### PR TITLE
Feature/issue 12 create show round performer test

### DIFF
--- a/src/main/java/com/culture/ticketing/show/api/RoundController.java
+++ b/src/main/java/com/culture/ticketing/show/api/RoundController.java
@@ -1,7 +1,7 @@
 package com.culture.ticketing.show.api;
 
-import com.culture.ticketing.show.application.ShowFacadeService;
-import com.culture.ticketing.show.application.dto.RoundWithPerformersSaveRequest;
+import com.culture.ticketing.show.application.RoundService;
+import com.culture.ticketing.show.application.dto.RoundSaveRequest;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,15 +13,15 @@ import javax.validation.Valid;
 @RequestMapping("/api/v1/rounds")
 public class RoundController {
 
-    private final ShowFacadeService showFacadeService;
+    private final RoundService roundService;
 
-    public RoundController(ShowFacadeService showFacadeService) {
-        this.showFacadeService = showFacadeService;
+    public RoundController(RoundService roundService) {
+        this.roundService = roundService;
     }
 
     @PostMapping
-    public void postRound(@Valid @RequestBody RoundWithPerformersSaveRequest request) {
+    public void postRound(@Valid @RequestBody RoundSaveRequest request) {
 
-        showFacadeService.createRoundWithPerformers(request);
+        roundService.createRound(request);
     }
 }

--- a/src/main/java/com/culture/ticketing/show/api/RoundPerformerController.java
+++ b/src/main/java/com/culture/ticketing/show/api/RoundPerformerController.java
@@ -1,0 +1,27 @@
+package com.culture.ticketing.show.api;
+
+import com.culture.ticketing.show.application.RoundPerformerService;
+import com.culture.ticketing.show.application.dto.RoundPerformersSaveRequest;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/round-performers")
+public class RoundPerformerController {
+
+    private final RoundPerformerService roundPerformerService;
+
+    public RoundPerformerController(RoundPerformerService roundPerformerService) {
+        this.roundPerformerService = roundPerformerService;
+    }
+
+    @PostMapping
+    public void postRoundPerformers(@Valid @RequestBody RoundPerformersSaveRequest request) {
+
+        roundPerformerService.createRoundPerformers(request);
+    }
+}

--- a/src/main/java/com/culture/ticketing/show/application/RoundPerformerService.java
+++ b/src/main/java/com/culture/ticketing/show/application/RoundPerformerService.java
@@ -1,5 +1,6 @@
 package com.culture.ticketing.show.application;
 
+import com.culture.ticketing.show.application.dto.RoundPerformersSaveRequest;
 import com.culture.ticketing.show.domain.Round;
 import com.culture.ticketing.show.domain.RoundPerformer;
 import com.culture.ticketing.show.infra.RoundPerformerRepository;
@@ -7,8 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 @Service
 public class RoundPerformerService {
@@ -24,20 +24,16 @@ public class RoundPerformerService {
     }
 
     @Transactional
-    public void createRoundPerformers(Long roundId, Set<Long> performerIds) {
+    public void createRoundPerformers(RoundPerformersSaveRequest request) {
 
-        Round round = roundService.findById(roundId);
+        Objects.requireNonNull(request.getRoundId(), "회차 아이디를 입력해주세요.");
+        Objects.requireNonNull(request.getPerformerIds(), "출연자 아이디 목록을 입력해주세요.");
 
-        performerService.checkShowPerformersExists(round.getShowId(), performerIds);
+        Round round = roundService.findById(request.getRoundId());
 
-        List<RoundPerformer> roundPerformers = performerIds.stream()
-                .map(performerId -> RoundPerformer.builder()
-                        .roundId(round.getRoundId())
-                        .performerId(performerId)
-                        .build())
-                .collect(Collectors.toList());
+        performerService.checkShowPerformersExists(round.getShowId(), request.getPerformerIds());
 
-        roundPerformerRepository.saveAll(roundPerformers);
+        roundPerformerRepository.saveAll(request.toEntities());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/culture/ticketing/show/application/RoundService.java
+++ b/src/main/java/com/culture/ticketing/show/application/RoundService.java
@@ -48,7 +48,7 @@ public class RoundService {
         roundRepository.save(round);
     }
 
-    protected void checkDuplicatedRoundDateTime(Round round) {
+    private void checkDuplicatedRoundDateTime(Round round) {
         roundRepository.findByShowIdAndDuplicatedRoundDateTime(
                 round.getShowId(),
                 round.getRoundStartDateTime(),
@@ -57,7 +57,7 @@ public class RoundService {
         });
     }
 
-    protected void checkOutOfRangeRoundDateTime(Round round, Show show) {
+    private void checkOutOfRangeRoundDateTime(Round round, Show show) {
         LocalDateTime showStartDateTime = LocalDateTime.of(show.getShowStartDate(), LocalTime.MIN);
         LocalDateTime showEndDateTime = LocalDateTime.of(show.getShowEndDate(), LocalTime.MAX);
         if (round.getRoundStartDateTime().isBefore(showStartDateTime)

--- a/src/main/java/com/culture/ticketing/show/application/RoundService.java
+++ b/src/main/java/com/culture/ticketing/show/application/RoundService.java
@@ -48,7 +48,7 @@ public class RoundService {
         roundRepository.save(round);
     }
 
-    private void checkDuplicatedRoundDateTime(Round round) {
+    protected void checkDuplicatedRoundDateTime(Round round) {
         roundRepository.findByShowIdAndDuplicatedRoundDateTime(
                 round.getShowId(),
                 round.getRoundStartDateTime(),
@@ -57,7 +57,7 @@ public class RoundService {
         });
     }
 
-    private void checkOutOfRangeRoundDateTime(Round round, Show show) {
+    protected void checkOutOfRangeRoundDateTime(Round round, Show show) {
         LocalDateTime showStartDateTime = LocalDateTime.of(show.getShowStartDate(), LocalTime.MIN);
         LocalDateTime showEndDateTime = LocalDateTime.of(show.getShowEndDate(), LocalTime.MAX);
         if (round.getRoundStartDateTime().isBefore(showStartDateTime)

--- a/src/main/java/com/culture/ticketing/show/application/RoundService.java
+++ b/src/main/java/com/culture/ticketing/show/application/RoundService.java
@@ -1,5 +1,6 @@
 package com.culture.ticketing.show.application;
 
+import com.culture.ticketing.show.application.dto.RoundSaveRequest;
 import com.culture.ticketing.show.domain.Round;
 import com.culture.ticketing.show.domain.Show;
 import com.culture.ticketing.show.exception.DuplicatedRoundDateTimeException;
@@ -12,14 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class RoundService {
 
     private final RoundRepository roundRepository;
+    private final ShowService showService;
 
-    public RoundService(RoundRepository roundRepository) {
+    public RoundService(RoundRepository roundRepository, ShowService showService) {
         this.roundRepository = roundRepository;
+        this.showService = showService;
     }
 
     @Transactional(readOnly = true)
@@ -30,7 +34,13 @@ public class RoundService {
     }
 
     @Transactional
-    public void createRound(Show show, Round round) {
+    public void createRound(RoundSaveRequest request) {
+
+        Objects.requireNonNull(request.getShowId(), "공연 아이디를 입력해주세요.");
+        Objects.requireNonNull(request.getRoundStartDateTime(), "시작 회차 일시를 입력해주세요.");
+
+        Show show = showService.findShowById(request.getShowId());
+        Round round = request.toEntity(show);
 
         checkOutOfRangeRoundDateTime(round, show);
         checkDuplicatedRoundDateTime(round);

--- a/src/main/java/com/culture/ticketing/show/application/ShowFacadeService.java
+++ b/src/main/java/com/culture/ticketing/show/application/ShowFacadeService.java
@@ -3,7 +3,6 @@ package com.culture.ticketing.show.application;
 import com.culture.ticketing.place.application.PlaceService;
 import com.culture.ticketing.place.domain.Place;
 import com.culture.ticketing.show.application.dto.RoundWithPerformersResponse;
-import com.culture.ticketing.show.application.dto.RoundWithPerformersSaveRequest;
 import com.culture.ticketing.show.application.dto.ShowDetailResponse;
 import com.culture.ticketing.show.application.dto.ShowSeatGradeResponse;
 import com.culture.ticketing.show.domain.Performer;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -49,20 +47,6 @@ public class ShowFacadeService {
         List<ShowSeatGradeResponse> showSeatGrades = showSeatGradeService.findShowSeatGradesByShowId(showId);
 
         return ShowDetailResponse.from(show, place, rounds, showSeatGrades);
-    }
-
-    @Transactional
-    public void createRoundWithPerformers(RoundWithPerformersSaveRequest request) {
-
-        Objects.requireNonNull(request.getShowId(), "공연 아이디를 입력해주세요.");
-        Objects.requireNonNull(request.getRoundStartDateTime(), "시작 회차 일시를 입력해주세요.");
-
-        Show show = showService.findShowById(request.getShowId());
-
-        Round round = request.toEntity(show);
-        roundService.createRound(show, round);
-
-        roundPerformerService.createRoundPerformers(round.getRoundId(), request.getPerformerIds());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/culture/ticketing/show/application/dto/RoundPerformersSaveRequest.java
+++ b/src/main/java/com/culture/ticketing/show/application/dto/RoundPerformersSaveRequest.java
@@ -1,0 +1,36 @@
+package com.culture.ticketing.show.application.dto;
+
+import com.culture.ticketing.show.domain.RoundPerformer;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class RoundPerformersSaveRequest {
+
+    @NotNull
+    private Long roundId;
+    @NotNull
+    private Set<Long> performerIds;
+
+    @Builder
+    public RoundPerformersSaveRequest(Long roundId, Set<Long> performerIds) {
+        this.roundId = roundId;
+        this.performerIds = performerIds;
+    }
+
+    public List<RoundPerformer> toEntities() {
+        return performerIds.stream()
+                .map(performerId -> RoundPerformer.builder()
+                        .roundId(roundId)
+                        .performerId(performerId)
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/culture/ticketing/show/application/dto/RoundSaveRequest.java
+++ b/src/main/java/com/culture/ticketing/show/application/dto/RoundSaveRequest.java
@@ -2,6 +2,7 @@ package com.culture.ticketing.show.application.dto;
 
 import com.culture.ticketing.show.domain.Round;
 import com.culture.ticketing.show.domain.Show;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +19,12 @@ public class RoundSaveRequest {
     @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'hh:mm:ss")
     private LocalDateTime roundStartDateTime;
+
+    @Builder
+    public RoundSaveRequest(Long showId, LocalDateTime roundStartDateTime) {
+        this.showId = showId;
+        this.roundStartDateTime = roundStartDateTime;
+    }
 
     public Round toEntity(Show show) {
         return Round.builder()

--- a/src/main/java/com/culture/ticketing/show/application/dto/RoundSaveRequest.java
+++ b/src/main/java/com/culture/ticketing/show/application/dto/RoundSaveRequest.java
@@ -8,18 +8,16 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.Set;
 
 @Getter
 @NoArgsConstructor
-public class RoundWithPerformersSaveRequest {
+public class RoundSaveRequest {
 
     @NotNull
     private Long showId;
     @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'hh:mm:ss")
     private LocalDateTime roundStartDateTime;
-    private Set<Long> performerIds;
 
     public Round toEntity(Show show) {
         return Round.builder()

--- a/src/main/java/com/culture/ticketing/show/domain/Performer.java
+++ b/src/main/java/com/culture/ticketing/show/domain/Performer.java
@@ -36,11 +36,12 @@ public class Performer extends BaseEntity {
     private Long showId;
 
     @Builder
-    public Performer(String performerName, String performerImgUrl, String role, Long showId) {
+    public Performer(Long performerId, String performerName, String performerImgUrl, String role, Long showId) {
 
         Objects.requireNonNull(showId, "공연 아이디를 입력해주세요.");
         Preconditions.checkArgument(StringUtils.hasText(performerName), "출연자 이름을 입력해주세요.");
 
+        this.performerId = performerId;
         this.performerName = performerName;
         this.performerImgUrl = performerImgUrl;
         this.role = role;

--- a/src/main/java/com/culture/ticketing/show/domain/Round.java
+++ b/src/main/java/com/culture/ticketing/show/domain/Round.java
@@ -33,12 +33,13 @@ public class Round extends BaseEntity {
     private Long showId;
 
     @Builder
-    public Round(LocalDateTime roundStartDateTime, LocalDateTime roundEndDateTime, Long showId) {
+    public Round(Long roundId, LocalDateTime roundStartDateTime, LocalDateTime roundEndDateTime, Long showId) {
 
         Objects.requireNonNull(showId, "공연 아이디를 입력해주세요.");
         Objects.requireNonNull(roundStartDateTime, "회차 시작 일시를 입력해주세요.");
         Objects.requireNonNull(roundEndDateTime, "회차 종료 일시를 입력해주세요.");
 
+        this.roundId = roundId;
         this.roundStartDateTime = roundStartDateTime;
         this.roundEndDateTime = roundEndDateTime;
         this.showId = showId;

--- a/src/main/java/com/culture/ticketing/show/domain/RoundPerformer.java
+++ b/src/main/java/com/culture/ticketing/show/domain/RoundPerformer.java
@@ -11,6 +11,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +30,10 @@ public class RoundPerformer {
 
     @Builder
     public RoundPerformer(Long roundId, Long performerId) {
+
+        Objects.requireNonNull(roundId, "회차 아이디를 입력해주세요.");
+        Objects.requireNonNull(performerId, "출연자 아이디를 입력해주세요.");
+
         this.roundId = roundId;
         this.performerId = performerId;
     }

--- a/src/main/java/com/culture/ticketing/show/domain/Show.java
+++ b/src/main/java/com/culture/ticketing/show/domain/Show.java
@@ -46,7 +46,7 @@ public class Show extends BaseEntity {
     private Long placeId;
 
     @Builder
-    public Show(Category category, String showName, AgeRestriction ageRestriction,
+    public Show(Long showId, Category category, String showName, AgeRestriction ageRestriction,
                 int runningTime, String notice, String posterImgUrl, String description,
                 LocalDate showStartDate, LocalDate showEndDate, Long placeId) {
 
@@ -59,6 +59,7 @@ public class Show extends BaseEntity {
         Preconditions.checkArgument(StringUtils.hasText(posterImgUrl), "공연 포스터 이미지 url을 입력해주세요.");
         Preconditions.checkArgument(runningTime > 0, "공연 러닝 시간을 0 초과로 입력해주세요.");
 
+        this.showId = showId;
         this.category = category;
         this.showName = showName;
         this.ageRestriction = ageRestriction;

--- a/src/main/java/com/culture/ticketing/show/infra/RoundRepositoryCustom.java
+++ b/src/main/java/com/culture/ticketing/show/infra/RoundRepositoryCustom.java
@@ -1,6 +1,5 @@
 package com.culture.ticketing.show.infra;
 
-import com.culture.ticketing.show.domain.Show;
 import com.culture.ticketing.show.domain.Round;
 
 import java.time.LocalDateTime;

--- a/src/test/groovy/com/culture/ticketing/place/api/PlaceControllerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/place/api/PlaceControllerTest.groovy
@@ -31,7 +31,7 @@ class PlaceControllerTest extends Specification {
     private PlaceService placeService = Mock()
 
 
-    def "장소_목록 조회"() {
+    def "장소 목록 조회"() {
 
         given:
         List<PlaceResponse> places = List.of(
@@ -57,7 +57,7 @@ class PlaceControllerTest extends Specification {
 
     }
 
-    def "장소_생성_성공"() {
+    def "장소 생성 성공"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -77,7 +77,7 @@ class PlaceControllerTest extends Specification {
 
     }
 
-    def "장소_생성_시_장소_주소가_null_인_경우_400_에러"() {
+    def "장소 생성 시 장소 주소가 null 인 경우 400 에러"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -97,7 +97,7 @@ class PlaceControllerTest extends Specification {
 
     }
 
-    def "장소_생성_시_장소_주소가_빈_값_인_경우_400_에러"() {
+    def "장소 생성 시 장소 주소가 빈 값인 경우 400 에러"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -117,7 +117,7 @@ class PlaceControllerTest extends Specification {
 
     }
 
-    def "장소_생성_시_위도가_null_인_경우_400_에러"() {
+    def "장소 생성 시 위도가 null 인 경우 400 에러"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -137,7 +137,7 @@ class PlaceControllerTest extends Specification {
 
     }
 
-    def "장소_생성_시_경도가_null_인_경우_400_에러"() {
+    def "장소생성 시 경도가 null 인 경우 400 에러"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()

--- a/src/test/groovy/com/culture/ticketing/place/application/PlaceServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/place/application/PlaceServiceTest.groovy
@@ -14,7 +14,7 @@ class PlaceServiceTest extends Specification {
     private PlaceRepository placeRepository = Mock();
     private PlaceService placeService = new PlaceService(placeRepository);
 
-    def "장소_목록_조회"() {
+    def "장소 목록 조회"() {
 
         given:
         List<Place> places = List.of(
@@ -33,7 +33,7 @@ class PlaceServiceTest extends Specification {
         response.collect(place -> place.placeId > 1L).size() == 3
     }
 
-    def "장소_생성_시_위도가_null_이면_예외_발생"() {
+    def "장소 생성 시 위도가 null 이면 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -51,7 +51,7 @@ class PlaceServiceTest extends Specification {
         e.message == "정확한 장소 위도를 입력해주세요."
     }
 
-    def "장소_생성_시_경도가_null_이면_예외_발생"() {
+    def "장소 생성 시 경도가 null 이면 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -69,7 +69,7 @@ class PlaceServiceTest extends Specification {
         e.message == "정확한 장소 경도를 입력해주세요."
     }
 
-    def "장소_생성_시_장소_주소가_null_이면_예외_발생"() {
+    def "장소 생성시 장소 주소가 null 이면 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -87,7 +87,7 @@ class PlaceServiceTest extends Specification {
         e.message == "장소 주소를 입력해주세요."
     }
 
-    def "장소_생성_시_장소 주소가_빈_값_이면_예외_발생"() {
+    def "장소 생성 시 장소 주소가 빈 값 이면 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -105,7 +105,7 @@ class PlaceServiceTest extends Specification {
         e.message == "장소 주소를 입력해주세요."
     }
 
-    def "장소_생성_시_위도_범위가_-90_미만인_경우_예외_발생"() {
+    def "장소 생성 시 위도 범위가 -90 미만인 경우 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -123,7 +123,7 @@ class PlaceServiceTest extends Specification {
         e.message == "장소 위도 범위를 벗어난 입력값입니다."
     }
 
-    def "장소_생성_시_위도_범위가_90_초과인_경우_예외_발생"() {
+    def "장소 생성 시 위도 범위가 90 초과인 경우 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -141,7 +141,7 @@ class PlaceServiceTest extends Specification {
         e.message == "장소 위도 범위를 벗어난 입력값입니다."
     }
 
-    def "장소_생성_시_경도_범위가_-180_미만인_경우_예외_발생"() {
+    def "장소 생성 시 경도 범위가 -180 미만인 경우 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -159,7 +159,7 @@ class PlaceServiceTest extends Specification {
         e.message == "장소 경도 범위를 벗어난 입력값입니다."
     }
 
-    def "장소_생성_시_경도_범위가_180_초과인_경우_예외_발생"() {
+    def "장소 생성 시 경도 범위가 180 초과인 경우 예외 발생"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()
@@ -177,7 +177,7 @@ class PlaceServiceTest extends Specification {
         e.message == "장소 경도 범위를 벗어난 입력값입니다."
     }
 
-    def "장소_생성_성공"() {
+    def "장소 생성 성공"() {
 
         given:
         PlaceSaveRequest request = PlaceSaveRequest.builder()

--- a/src/test/groovy/com/culture/ticketing/place/domain/PlaceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/place/domain/PlaceTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 class PlaceTest extends Specification {
 
-    def "Place_생성_시_위도가_null_이면_예외_발생"() {
+    def "Place 생성 시 위도가 null 이면 예외 발생"() {
 
         when:
         Place.builder()
@@ -19,7 +19,7 @@ class PlaceTest extends Specification {
         e.message == "정확한 장소 위도를 입력해주세요."
     }
 
-    def "Place_생성_시_경도가_null_이면_예외_발생"() {
+    def "Place 생성 시 경도가 null 이면 예외 발생"() {
 
         when:
         Place.builder()
@@ -34,7 +34,7 @@ class PlaceTest extends Specification {
         e.message == "정확한 장소 경도를 입력해주세요."
     }
 
-    def "Place_생성_시_장소_주소가_null_이면_예외_발생"() {
+    def "Place 생성 시 장소 주소가 null 이면 예외 발생"() {
 
         when:
         Place.builder()
@@ -49,7 +49,7 @@ class PlaceTest extends Specification {
         e.message == "장소 주소를 입력해주세요."
     }
 
-    def "Place_생성_시_장소 주소가_빈_값_이면_예외_발생"() {
+    def "Place 생성 시 장소 주소가 빈 값이면 예외 발생"() {
 
         when:
         Place.builder()
@@ -64,7 +64,7 @@ class PlaceTest extends Specification {
         e.message == "장소 주소를 입력해주세요."
     }
 
-    def "Place_생성_시_위도_범위가_-90_미만인_경우_예외_발생"() {
+    def "Place 생성 시 위도 범위가 -90 미만인 경우 예외 발생"() {
 
         when:
         Place.builder()
@@ -79,7 +79,7 @@ class PlaceTest extends Specification {
         e.message == "장소 위도 범위를 벗어난 입력값입니다."
     }
 
-    def "Place_생성_시_위도_범위가_90_초과인_경우_예외_발생"() {
+    def "Place 생성 시 위도 범위가 90 초과인 경우 예외 발생"() {
 
         when:
         Place.builder()
@@ -94,7 +94,7 @@ class PlaceTest extends Specification {
         e.message == "장소 위도 범위를 벗어난 입력값입니다."
     }
 
-    def "Place_생성_시_경도_범위가_-180_미만인_경우_예외_발생"() {
+    def "Place 생성 시 경도 범위가 -180 미만인 경우 예외 발생"() {
 
         when:
         Place.builder()
@@ -109,7 +109,7 @@ class PlaceTest extends Specification {
         e.message == "장소 경도 범위를 벗어난 입력값입니다."
     }
 
-    def "Place_생성_시_경도_범위가_180_초과인_경우_예외_발생"() {
+    def "Place 생성 시 경도 범위가 180 초과인 경우 예외 발생"() {
 
         when:
         Place.builder()

--- a/src/test/groovy/com/culture/ticketing/place/infra/PlaceRepositoryCustomTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/place/infra/PlaceRepositoryCustomTest.groovy
@@ -14,7 +14,7 @@ class PlaceRepositoryCustomTest extends Specification {
     @Autowired
     private PlaceRepository placeRepository;
 
-    def "장소_목록_조회_테스트_특정한_아이디보다_크고_사이즈_제한"() {
+    def "장소 목록 조회 테스트 - 특정한 아이디보다 크고 사이즈 제한"() {
 
         given:
         List<Place> places = List.of(

--- a/src/test/groovy/com/culture/ticketing/show/PerformerFixtures.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/PerformerFixtures.groovy
@@ -1,0 +1,16 @@
+package com.culture.ticketing.show
+
+import com.culture.ticketing.show.domain.Performer;
+
+class PerformerFixtures {
+
+    static Performer createPerformer(Long performerId, Long showId = 1L, String performerName = "홍길동", String performerImgUrl = "https://abc.jpg", String role = "ABC") {
+        return Performer.builder()
+                .performerId(performerId)
+                .showId(showId)
+                .performerName(performerName)
+                .performerImgUrl(performerImgUrl)
+                .role(role)
+                .build();
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/RoundFixtures.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/RoundFixtures.groovy
@@ -1,0 +1,20 @@
+package com.culture.ticketing.show
+
+import com.culture.ticketing.show.domain.Round
+
+import java.time.LocalDateTime
+
+class RoundFixtures {
+
+    static Round createRound(Long roundId,
+                             Long showId = 1L,
+                             LocalDateTime roundStartDateTime = LocalDateTime.of(2024, 1, 1, 10, 0, 0),
+                             LocalDateTime roundEndDateTime = LocalDateTime.of(2024, 1, 1, 12, 0, 0)) {
+        return Round.builder()
+                .roundId(roundId)
+                .showId(showId)
+                .roundStartDateTime(roundStartDateTime)
+                .roundEndDateTime(roundEndDateTime)
+                .build();
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/api/RoundControllerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/api/RoundControllerTest.groovy
@@ -1,0 +1,83 @@
+package com.culture.ticketing.show.api
+
+import com.culture.ticketing.show.application.RoundService
+import com.culture.ticketing.show.application.ShowFacadeService
+import com.culture.ticketing.show.application.dto.RoundSaveRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(RoundController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class RoundControllerTest extends Specification {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @SpringBean
+    private RoundService roundService = Mock();
+
+    def "회차_생성_성공"() {
+
+        given:
+        RoundSaveRequest request = RoundSaveRequest.builder()
+                .showId(1L)
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .build();
+
+        expect:
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rounds")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print())
+    }
+
+    def "회차_생성_시_공연_아이디가_null_인_경우_400_에러"() {
+
+        given:
+        RoundSaveRequest request = RoundSaveRequest.builder()
+                .showId(null)
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .build();
+
+        expect:
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rounds")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+    }
+
+    def "회차_생성_시_회차_시작_일시가_null_인_경우_400_에러"() {
+
+        given:
+        RoundSaveRequest request = RoundSaveRequest.builder()
+                .showId(1L)
+                .roundStartDateTime(null)
+                .build();
+
+        expect:
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rounds")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/api/RoundControllerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/api/RoundControllerTest.groovy
@@ -30,7 +30,7 @@ class RoundControllerTest extends Specification {
     @SpringBean
     private RoundService roundService = Mock();
 
-    def "회차_생성_성공"() {
+    def "회차 생성 성공"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -47,7 +47,7 @@ class RoundControllerTest extends Specification {
                 .andDo(MockMvcResultHandlers.print())
     }
 
-    def "회차_생성_시_공연_아이디가_null_인_경우_400_에러"() {
+    def "회차 생성 시 공연 아이디가 null 인 경우 400 에러"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -64,7 +64,7 @@ class RoundControllerTest extends Specification {
                 .andDo(MockMvcResultHandlers.print())
     }
 
-    def "회차_생성_시_회차_시작_일시가_null_인_경우_400_에러"() {
+    def "회차 생성 시 회차 시작 일시가 null 인 경우 400 에러"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()

--- a/src/test/groovy/com/culture/ticketing/show/api/RoundPerformerControllerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/api/RoundPerformerControllerTest.groovy
@@ -1,0 +1,80 @@
+package com.culture.ticketing.show.api
+
+import com.culture.ticketing.show.application.RoundPerformerService
+import com.culture.ticketing.show.application.dto.RoundPerformersSaveRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(RoundPerformerController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class RoundPerformerControllerTest extends Specification {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @SpringBean
+    private RoundPerformerService performerService = Mock();
+
+    def "회차_출연자_목록_생성_성공"() {
+
+        given:
+        RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
+                .roundId(1L)
+                .performerIds(Set.of(1L, 2L, 3L))
+                .build();
+
+        expect:
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/round-performers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print())
+    }
+
+    def "회차_출연자_목록_생성_시_회차_아이디가_null_인_경우_400_에러"() {
+
+        given:
+        RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
+                .roundId(null)
+                .performerIds(Set.of(1L, 2L, 3L))
+                .build();
+
+        expect:
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/round-performers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+    }
+
+    def "회차_출연자_목록_생성_시_출연자_아이디_목록_null_인_경우_400_에러"() {
+
+        given:
+        RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
+                .roundId(1L)
+                .performerIds(null)
+                .build();
+
+        expect:
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/round-performers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/api/RoundPerformerControllerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/api/RoundPerformerControllerTest.groovy
@@ -25,9 +25,9 @@ class RoundPerformerControllerTest extends Specification {
     @Autowired
     private ObjectMapper objectMapper;
     @SpringBean
-    private RoundPerformerService performerService = Mock();
+    private RoundPerformerService roundPerformerService = Mock();
 
-    def "회차_출연자_목록_생성_성공"() {
+    def "회차 출연자 목록 생성 성공"() {
 
         given:
         RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
@@ -44,7 +44,7 @@ class RoundPerformerControllerTest extends Specification {
                 .andDo(MockMvcResultHandlers.print())
     }
 
-    def "회차_출연자_목록_생성_시_회차_아이디가_null_인_경우_400_에러"() {
+    def "회차 출연자 목록 생성 시 회차 아이디가 null 인경우 400 에러"() {
 
         given:
         RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
@@ -61,7 +61,7 @@ class RoundPerformerControllerTest extends Specification {
                 .andDo(MockMvcResultHandlers.print())
     }
 
-    def "회차_출연자_목록_생성_시_출연자_아이디_목록_null_인_경우_400_에러"() {
+    def "회차 출연자 목록 생성 시 출연자 아이디 목록 null 인 경우 400 에러"() {
 
         given:
         RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()

--- a/src/test/groovy/com/culture/ticketing/show/application/PerformerServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/PerformerServiceTest.groovy
@@ -1,0 +1,56 @@
+package com.culture.ticketing.show.application
+
+import com.culture.ticketing.show.PerformerFixtures
+import com.culture.ticketing.show.domain.Performer
+import com.culture.ticketing.show.exception.ShowPerformerNotMatchException
+import com.culture.ticketing.show.infra.PerformerRepository
+import org.spockframework.spring.SpringBean
+import spock.lang.Specification
+
+class PerformerServiceTest extends Specification {
+
+    @SpringBean
+    private PerformerRepository performerRepository = Mock();
+    @SpringBean
+    private ShowService showService = Mock();
+    private PerformerService performerService = new PerformerService(performerRepository, showService);
+
+    def "공연_아이디와_출연자_아이디_목록으로_출연자_목록_조회"() {
+
+        given:
+        List<Performer> performers = List.of(
+                PerformerFixtures.createPerformer(1L, 1L),
+                PerformerFixtures.createPerformer(2L, 1L),
+                PerformerFixtures.createPerformer(3L, 2L),
+                PerformerFixtures.createPerformer(4L, 1L),
+                PerformerFixtures.createPerformer(5L, 3L)
+        );
+        performerRepository.findByShowIdAndPerformerIdIn(1L, List.of(1L, 2L, 3L)) >> List.of(performers.get(0), performers.get(1))
+
+        when:
+        List<Performer> foundPerformers = performerService.findShowPerformers(1L, List.of(1L, 2L, 3L));
+
+        then:
+        foundPerformers.collect(performer -> performer.performerId) == [1L, 2L]
+    }
+
+    def "출연자_목록_중_해당_공연_출연자가_아닌_경우_예외_발생"() {
+
+        given:
+        List<Performer> performers = List.of(
+                PerformerFixtures.createPerformer(1L, 1L),
+                PerformerFixtures.createPerformer(2L, 1L),
+                PerformerFixtures.createPerformer(3L, 2L),
+                PerformerFixtures.createPerformer(4L, 1L),
+                PerformerFixtures.createPerformer(5L, 3L)
+        );
+        performerRepository.findByShowIdAndPerformerIdIn(1L, Set.of(1L, 2L, 3L)) >> List.of(performers.get(0), performers.get(1))
+
+        when:
+        performerService.checkShowPerformersExists(1L, Set.of(1L, 2L, 3L));
+
+        then:
+        def e = thrown(ShowPerformerNotMatchException.class)
+        e.message == "해당 공연의 출연자가 아닌 값이 포함되어 있습니다. (performerIds = [3])"
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/application/PerformerServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/PerformerServiceTest.groovy
@@ -15,7 +15,7 @@ class PerformerServiceTest extends Specification {
     private ShowService showService = Mock();
     private PerformerService performerService = new PerformerService(performerRepository, showService);
 
-    def "공연_아이디와_출연자_아이디_목록으로_출연자_목록_조회"() {
+    def "공연 아이디와 출연자 아이디 목록으로 출연자 목록 조회"() {
 
         given:
         List<Performer> performers = List.of(
@@ -34,7 +34,7 @@ class PerformerServiceTest extends Specification {
         foundPerformers.collect(performer -> performer.performerId) == [1L, 2L]
     }
 
-    def "출연자_목록_중_해당_공연_출연자가_아닌_경우_예외_발생"() {
+    def "출연자 목록 중 해당 공연 출연자가 아닌 경우 예외 발생"() {
 
         given:
         List<Performer> performers = List.of(

--- a/src/test/groovy/com/culture/ticketing/show/application/RoundPerformerServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/RoundPerformerServiceTest.groovy
@@ -1,5 +1,6 @@
 package com.culture.ticketing.show.application
 
+import com.culture.ticketing.show.RoundFixtures
 import com.culture.ticketing.show.application.dto.RoundPerformersSaveRequest
 import com.culture.ticketing.show.infra.RoundPerformerRepository
 import org.spockframework.spring.SpringBean
@@ -45,5 +46,21 @@ class RoundPerformerServiceTest extends Specification {
         then:
         def e = thrown(NullPointerException.class)
         e.message == "출연자 아이디 목록을 입력해주세요."
+    }
+
+    def "회차_출연자_목록_생성_성공"() {
+
+        given:
+        RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
+                .roundId(1L)
+                .performerIds(Set.of(1L, 2L, 3L))
+                .build();
+        roundService.findById(1L) >> RoundFixtures.createRound(1L)
+
+        when:
+        roundPerformerService.createRoundPerformers(request);
+
+        then:
+        1 * roundPerformerRepository.saveAll(_)
     }
 }

--- a/src/test/groovy/com/culture/ticketing/show/application/RoundPerformerServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/RoundPerformerServiceTest.groovy
@@ -16,7 +16,7 @@ class RoundPerformerServiceTest extends Specification {
     private RoundService roundService = Mock();
     private RoundPerformerService roundPerformerService = new RoundPerformerService(roundPerformerRepository, performerService, roundService);
 
-    def "회차_출연자_목록_생성_시_회차_아이디가_null_인_경우_예외_발생"() {
+    def "회차 출연자 목록 생성 시 회차 아이디가 null 인 경우 예외 발생"() {
 
         given:
         RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
@@ -32,7 +32,7 @@ class RoundPerformerServiceTest extends Specification {
         e.message == "회차 아이디를 입력해주세요."
     }
 
-    def "회차_출연자_목록_생성_시_출연자_아이디_목록이_null_인_경우_예외_발생"() {
+    def "회차 출연자 목록 생성 시 출연자 아이디 목록이 null 인 경우 예외 발생"() {
 
         given:
         RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
@@ -48,7 +48,7 @@ class RoundPerformerServiceTest extends Specification {
         e.message == "출연자 아이디 목록을 입력해주세요."
     }
 
-    def "회차_출연자_목록_생성_성공"() {
+    def "회차 출연자 목록 생성 성공"() {
 
         given:
         RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()

--- a/src/test/groovy/com/culture/ticketing/show/application/RoundPerformerServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/RoundPerformerServiceTest.groovy
@@ -1,0 +1,49 @@
+package com.culture.ticketing.show.application
+
+import com.culture.ticketing.show.application.dto.RoundPerformersSaveRequest
+import com.culture.ticketing.show.infra.RoundPerformerRepository
+import org.spockframework.spring.SpringBean
+import spock.lang.Specification
+
+class RoundPerformerServiceTest extends Specification {
+
+    @SpringBean
+    private RoundPerformerRepository roundPerformerRepository = Mock();
+    @SpringBean
+    private PerformerService performerService = Mock();
+    @SpringBean
+    private RoundService roundService = Mock();
+    private RoundPerformerService roundPerformerService = new RoundPerformerService(roundPerformerRepository, performerService, roundService);
+
+    def "회차_출연자_목록_생성_시_회차_아이디가_null_인_경우_예외_발생"() {
+
+        given:
+        RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
+                .roundId(null)
+                .performerIds(Set.of(1L, 2L, 3L))
+                .build();
+
+        when:
+        roundPerformerService.createRoundPerformers(request);
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "회차 아이디를 입력해주세요."
+    }
+
+    def "회차_출연자_목록_생성_시_출연자_아이디_목록이_null_인_경우_예외_발생"() {
+
+        given:
+        RoundPerformersSaveRequest request = RoundPerformersSaveRequest.builder()
+                .roundId(1L)
+                .performerIds(null)
+                .build();
+
+        when:
+        roundPerformerService.createRoundPerformers(request);
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "출연자 아이디 목록을 입력해주세요."
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/application/RoundServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/RoundServiceTest.groovy
@@ -1,0 +1,140 @@
+package com.culture.ticketing.show.application
+
+import com.culture.ticketing.show.RoundFixtures
+import com.culture.ticketing.show.application.dto.RoundSaveRequest
+import com.culture.ticketing.show.domain.AgeRestriction
+import com.culture.ticketing.show.domain.Category
+import com.culture.ticketing.show.domain.Round
+import com.culture.ticketing.show.domain.Show
+import com.culture.ticketing.show.exception.DuplicatedRoundDateTimeException
+import com.culture.ticketing.show.exception.OutOfRangeRoundDateTimeException
+import com.culture.ticketing.show.exception.RoundNotFoundException
+import com.culture.ticketing.show.infra.RoundRepository
+import org.spockframework.spring.SpringBean
+import spock.lang.Specification
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class RoundServiceTest extends Specification {
+
+    @SpringBean
+    private RoundRepository roundRepository = Mock();
+    @SpringBean
+    private ShowService showService = Mock();
+    private RoundService roundService = new RoundService(roundRepository, showService);
+
+    def "회차_생성_시_공연_아이디가_null_인_경우_예외_생성"() {
+
+        given:
+        RoundSaveRequest request = RoundSaveRequest.builder()
+                .showId(null)
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .build();
+
+        when:
+        roundService.createRound(request);
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "공연 아이디를 입력해주세요."
+    }
+
+    def "회차_생성_시_회차_시작_일시가_null_인_경우_예외_생성"() {
+
+        given:
+        RoundSaveRequest request = RoundSaveRequest.builder()
+                .showId(1L)
+                .roundStartDateTime(null)
+                .build();
+
+        when:
+        roundService.createRound(request);
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "시작 회차 일시를 입력해주세요."
+    }
+
+    def "회차_아이디로_회차_조회_시_존재하지_않는_경우_예외_발생"() {
+
+        given:
+        roundRepository.findById(1L) >> Optional.empty()
+
+        when:
+        roundService.findById(1L);
+
+        then:
+        def e = thrown(RoundNotFoundException.class)
+        e.message == "존재하지 않는 회차입니다. (roundId = 1)"
+    }
+
+    def "공연_아이디_값으로_회차_목록_조회"() {
+
+        given:
+        List<Round> rounds = List.of(
+                RoundFixtures.createRound(1L, 1L),
+                RoundFixtures.createRound(2L, 1L),
+                RoundFixtures.createRound(3L, 2L),
+                RoundFixtures.createRound(4L, 1L),
+                RoundFixtures.createRound(5L, 3L)
+        );
+        roundRepository.findByShowId(1L) >> List.of(rounds.get(0), rounds.get(1), rounds.get(3))
+
+        when:
+        List<Round> foundRounds = roundService.findByShowId(1L);
+
+        then:
+        foundRounds.collect(round -> round.showId == 1L).size() == 3
+        foundRounds.collect(round -> round.roundId) == [1L, 2L, 4L]
+
+    }
+
+    def "중복_회차_일시_있는_경우_예외_발생"() {
+
+        given:
+        Round round = Round.builder()
+                .showId(1L)
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .roundEndDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .build();
+
+        roundRepository.findByShowIdAndDuplicatedRoundDateTime(round.getShowId(), round.getRoundStartDateTime(), round.getRoundEndDateTime()) >> Optional.of(round)
+
+        when:
+        roundService.checkDuplicatedRoundDateTime(round);
+
+        then:
+        def e = thrown(DuplicatedRoundDateTimeException.class)
+        e.message == "해당 공연에 일정이 동일한 회차가 이미 존재합니다."
+    }
+
+    def "공연_회차_일시_범위를_벗어난_경우_예외_발생"() {
+
+        given:
+        Show show = Show.builder()
+                .showId(1L)
+                .category(Category.CONCERT)
+                .ageRestriction(AgeRestriction.ALL)
+                .placeId(1L)
+                .showStartDate(LocalDate.of(2024, 1, 5))
+                .showEndDate(LocalDate.of(2024, 2, 20))
+                .showName("테스트 공연")
+                .posterImgUrl("http://abc.jpg")
+                .runningTime(120)
+                .build();
+
+        Round round = Round.builder()
+                .showId(1L)
+                .roundStartDateTime(LocalDateTime.of(2024, 2, 21, 0, 0, 0))
+                .roundEndDateTime(LocalDateTime.of(2024, 2, 21, 2, 0, 0))
+                .build();
+
+        when:
+        roundService.checkOutOfRangeRoundDateTime(round, show);
+
+        then:
+        def e = thrown(OutOfRangeRoundDateTimeException.class)
+        e.message == "공연 가능한 회차 날짜 범위를 벗어난 입력값입니다."
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/application/RoundServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/RoundServiceTest.groovy
@@ -24,7 +24,7 @@ class RoundServiceTest extends Specification {
     private ShowService showService = Mock();
     private RoundService roundService = new RoundService(roundRepository, showService);
 
-    def "회사_생성_성공"() {
+    def "회차 생성 성공"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -56,7 +56,7 @@ class RoundServiceTest extends Specification {
         1 * roundRepository.save(_)
     }
 
-    def "회차_생성_시_공연_아이디가_null_인_경우_예외_생성"() {
+    def "회차 생성 시 공연 아이디가 null 인 경우 예외 생성"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -72,7 +72,7 @@ class RoundServiceTest extends Specification {
         e.message == "공연 아이디를 입력해주세요."
     }
 
-    def "회차_생성_시_회차_시작_일시가_null_인_경우_예외_생성"() {
+    def "회차 생성 시 회차 시작 일시가 null 인 경우 예외 생성"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -88,7 +88,7 @@ class RoundServiceTest extends Specification {
         e.message == "시작 회차 일시를 입력해주세요."
     }
 
-    def "회차_아이디로_회차_조회_시_존재하지_않는_경우_예외_발생"() {
+    def "회차 아이디로 회차 조회 시 존재하지 않는 경우 예외 발생"() {
 
         given:
         roundRepository.findById(1L) >> Optional.empty()
@@ -101,7 +101,7 @@ class RoundServiceTest extends Specification {
         e.message == "존재하지 않는 회차입니다. (roundId = 1)"
     }
 
-    def "공연_아이디_값으로_회차_목록_조회"() {
+    def "공연 아이디 값으로 회차 목록 조회"() {
 
         given:
         List<Round> rounds = List.of(
@@ -122,7 +122,7 @@ class RoundServiceTest extends Specification {
 
     }
 
-    def "회차_생성_시_중복_회차_일시_있는_경우_예외_발생"() {
+    def "회차 생성 시 중복 회차 일시 있는 경우 예외 발생"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -155,7 +155,7 @@ class RoundServiceTest extends Specification {
         e.message == "해당 공연에 일정이 동일한 회차가 이미 존재합니다."
     }
 
-    def "회사_생성_시_공연_회차_일시_범위를_벗어난_경우_예외_발생"() {
+    def "회차 생성 시 공연 회차 일시 범위를 벗어난 경우 예외 발생"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()

--- a/src/test/groovy/com/culture/ticketing/show/application/RoundServiceTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/application/RoundServiceTest.groovy
@@ -122,26 +122,7 @@ class RoundServiceTest extends Specification {
 
     }
 
-    def "중복_회차_일시_있는_경우_예외_발생"() {
-
-        given:
-        Round round = Round.builder()
-                .showId(1L)
-                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
-                .roundEndDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
-                .build();
-
-        roundRepository.findByShowIdAndDuplicatedRoundDateTime(round.getShowId(), round.getRoundStartDateTime(), round.getRoundEndDateTime()) >> Optional.of(round)
-
-        when:
-        roundService.checkDuplicatedRoundDateTime(round);
-
-        then:
-        def e = thrown(DuplicatedRoundDateTimeException.class)
-        e.message == "해당 공연에 일정이 동일한 회차가 이미 존재합니다."
-    }
-
-    def "회사_생성_시_중복_회차_일시_있는_경우_예외_발생"() {
+    def "회차_생성_시_중복_회차_일시_있는_경우_예외_발생"() {
 
         given:
         RoundSaveRequest request = RoundSaveRequest.builder()
@@ -154,7 +135,7 @@ class RoundServiceTest extends Specification {
                 .category(Category.CONCERT)
                 .ageRestriction(AgeRestriction.ALL)
                 .placeId(1L)
-                .showStartDate(LocalDate.of(2024, 1, 5))
+                .showStartDate(LocalDate.of(2024, 1, 1))
                 .showEndDate(LocalDate.of(2024, 2, 20))
                 .showName("테스트 공연")
                 .posterImgUrl("http://abc.jpg")
@@ -170,37 +151,8 @@ class RoundServiceTest extends Specification {
         roundService.createRound(request);
 
         then:
-        def e = thrown(OutOfRangeRoundDateTimeException.class)
-        e.message == "공연 가능한 회차 날짜 범위를 벗어난 입력값입니다."
-    }
-
-    def "공연_회차_일시_범위를_벗어난_경우_예외_발생"() {
-
-        given:
-        Show show = Show.builder()
-                .showId(1L)
-                .category(Category.CONCERT)
-                .ageRestriction(AgeRestriction.ALL)
-                .placeId(1L)
-                .showStartDate(LocalDate.of(2024, 1, 5))
-                .showEndDate(LocalDate.of(2024, 2, 20))
-                .showName("테스트 공연")
-                .posterImgUrl("http://abc.jpg")
-                .runningTime(120)
-                .build();
-
-        Round round = Round.builder()
-                .showId(1L)
-                .roundStartDateTime(LocalDateTime.of(2024, 2, 21, 0, 0, 0))
-                .roundEndDateTime(LocalDateTime.of(2024, 2, 21, 2, 0, 0))
-                .build();
-
-        when:
-        roundService.checkOutOfRangeRoundDateTime(round, show);
-
-        then:
-        def e = thrown(OutOfRangeRoundDateTimeException.class)
-        e.message == "공연 가능한 회차 날짜 범위를 벗어난 입력값입니다."
+        def e = thrown(DuplicatedRoundDateTimeException.class)
+        e.message == "해당 공연에 일정이 동일한 회차가 이미 존재합니다."
     }
 
     def "회사_생성_시_공연_회차_일시_범위를_벗어난_경우_예외_발생"() {

--- a/src/test/groovy/com/culture/ticketing/show/domain/RoundPerformerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/domain/RoundPerformerTest.groovy
@@ -1,0 +1,32 @@
+package com.culture.ticketing.show.domain
+
+import spock.lang.Specification
+
+class RoundPerformerTest extends Specification {
+
+    def "회차_출연자_생성_시_회차_아이디가_null_인_경우_예외_발생"() {
+
+        when:
+        RoundPerformer.builder()
+                .roundId(null)
+                .performerId(1L)
+                .build();
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "회차 아이디를 입력해주세요."
+    }
+
+    def "회차_출연자_생성_시_출연자_아이디가_null_인_경우_예외_발생"() {
+
+        when:
+        RoundPerformer.builder()
+                .roundId(1L)
+                .performerId(null)
+                .build();
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "출연자 아이디를 입력해주세요."
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/domain/RoundPerformerTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/domain/RoundPerformerTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 class RoundPerformerTest extends Specification {
 
-    def "회차_출연자_생성_시_회차_아이디가_null_인_경우_예외_발생"() {
+    def "회차 출연자 생성 시 회차 아이디가 null 인 경우 예외 발생"() {
 
         when:
         RoundPerformer.builder()
@@ -17,7 +17,7 @@ class RoundPerformerTest extends Specification {
         e.message == "회차 아이디를 입력해주세요."
     }
 
-    def "회차_출연자_생성_시_출연자_아이디가_null_인_경우_예외_발생"() {
+    def "회차 출연자 생성 시 출연자 아이디가 null 인 경우 예외 발생"() {
 
         when:
         RoundPerformer.builder()

--- a/src/test/groovy/com/culture/ticketing/show/domain/RoundTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/domain/RoundTest.groovy
@@ -1,13 +1,12 @@
 package com.culture.ticketing.show.domain
 
-import com.culture.ticketing.show.RoundFixtures
 import spock.lang.Specification
 
 import java.time.LocalDateTime
 
 class RoundTest extends Specification {
 
-    def "회차_생성_시_공연_아이디가_null_인_경우_예외_발생"() {
+    def "회차 생성 시 공연 아이디가 null 인 경우 예외 발생"() {
 
         when:
         Round.builder()
@@ -21,7 +20,7 @@ class RoundTest extends Specification {
         e.message == "공연 아이디를 입력해주세요."
     }
 
-    def "회차_생성_시_회차_시작_일시_가_null_인_경우_예외_발생"() {
+    def "회차 생성 시 회차 시작 일시가 null 인 경우 예외 발생"() {
 
         when:
         Round.builder()
@@ -35,7 +34,7 @@ class RoundTest extends Specification {
         e.message == "회차 시작 일시를 입력해주세요."
     }
 
-    def "회차_생성_시_회차_종료_일시가_null_인_경우_예외_발생"() {
+    def "회차 생성 시 회차 종료 일시가 null 인 경우 예외 발생"() {
 
         when:
         Round.builder()

--- a/src/test/groovy/com/culture/ticketing/show/domain/RoundTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/domain/RoundTest.groovy
@@ -1,0 +1,51 @@
+package com.culture.ticketing.show.domain
+
+import com.culture.ticketing.show.RoundFixtures
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+
+class RoundTest extends Specification {
+
+    def "회차_생성_시_공연_아이디가_null_인_경우_예외_발생"() {
+
+        when:
+        Round.builder()
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .roundEndDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .showId(null)
+                .build();
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "공연 아이디를 입력해주세요."
+    }
+
+    def "회차_생성_시_회차_시작_일시_가_null_인_경우_예외_발생"() {
+
+        when:
+        Round.builder()
+                .roundStartDateTime(null)
+                .roundEndDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .showId(1L)
+                .build();
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "회차 시작 일시를 입력해주세요."
+    }
+
+    def "회차_생성_시_회차_종료_일시가_null_인_경우_예외_발생"() {
+
+        when:
+        Round.builder()
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .roundEndDateTime(null)
+                .showId(1L)
+                .build();
+
+        then:
+        def e = thrown(NullPointerException.class)
+        e.message == "회차 종료 일시를 입력해주세요."
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/infra/RoundRepositoryCustomTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/infra/RoundRepositoryCustomTest.groovy
@@ -1,0 +1,37 @@
+package com.culture.ticketing.show.infra
+
+import com.culture.ticketing.show.domain.Round
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RoundRepositoryCustomTest extends Specification {
+
+    @Autowired
+    private RoundRepository roundRepository;
+
+    def "회차_중_같은_공연_일시_겹치는_회차_조회"() {
+
+        given:
+        Round round = Round.builder()
+                .roundStartDateTime(LocalDateTime.of(2024, 1, 1, 10, 0, 0))
+                .roundEndDateTime(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+                .showId(1L)
+                .build();
+        roundRepository.save(round);
+
+        when:
+        Optional<Round> foundRound = roundRepository.findByShowIdAndDuplicatedRoundDateTime(1L,
+                LocalDateTime.of(2024, 1, 1, 12, 0, 0),
+                LocalDateTime.of(2024, 1, 1, 14, 0, 0)
+        );
+
+        then:
+        foundRound.isPresent()
+    }
+}

--- a/src/test/groovy/com/culture/ticketing/show/infra/RoundRepositoryCustomTest.groovy
+++ b/src/test/groovy/com/culture/ticketing/show/infra/RoundRepositoryCustomTest.groovy
@@ -15,7 +15,7 @@ class RoundRepositoryCustomTest extends Specification {
     @Autowired
     private RoundRepository roundRepository;
 
-    def "회차_중_같은_공연_일시_겹치는_회차_조회"() {
+    def "회차 중 같은 공연 일시 겹치는 회차 조회"() {
 
         given:
         Round round = Round.builder()


### PR DESCRIPTION
issue: #12 

- 이전 PR에서 제시해주신대로 회차 생성과 회차 출연자 목록 생성 기능 분리했습니다. 
  - 기존에는 따로 등록하는 게 오히려 불편하지 않을까 싶어서 했는데 더 생각해보니까 분리하는 게 더 맞을 것 같아서 분리했습니다.
- 회차 생성 테스트 추가
- 회차 출연자 목록 생성 테스트 추가