### PR TITLE
Feature/add querydsl fulltext search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,19 @@ plugins {
     id 'groovy'
 }
 
-subprojects {
+allprojects {
 
     group = 'com.culture'
     version = '0.0.1-SNAPSHOT'
+
+    repositories {
+        mavenCentral()
+        // jitpack.io를 저장소로 추가
+        maven { url 'https://jitpack.io' }
+    }
+}
+
+subprojects {
 
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
@@ -21,12 +30,6 @@ subprojects {
         compileOnly {
             extendsFrom annotationProcessor
         }
-    }
-
-    repositories {
-        mavenCentral()
-        // jitpack.io를 저장소로 추가
-        maven { url 'https://jitpack.io' }
     }
 
     dependencies {

--- a/culture-ticketing-api-server/src/main/resources/application.yml
+++ b/culture-ticketing-api-server/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+        dialect: com.culture.ticketing.common.infra.MySQL8DialectCustom
 
   mvc:
     pathmatch:

--- a/culture-ticketing-batch-server/src/main/resources/application.yml
+++ b/culture-ticketing-batch-server/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+        dialect: com.culture.ticketing.common.infra.MySQL8DialectCustom
 
   redis:
     host: host.docker.internal

--- a/culture-ticketing-core/src/main/java/com/culture/ticketing/common/infra/MySQL8DialectCustom.java
+++ b/culture-ticketing-core/src/main/java/com/culture/ticketing/common/infra/MySQL8DialectCustom.java
@@ -1,0 +1,18 @@
+package com.culture.ticketing.common.infra;
+
+import org.hibernate.dialect.MySQL8Dialect;
+import org.hibernate.dialect.function.SQLFunctionTemplate;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MySQL8DialectCustom extends MySQL8Dialect {
+
+    public MySQL8DialectCustom() {
+
+        super();
+
+        registerFunction(
+                "match",
+                new SQLFunctionTemplate(StandardBasicTypes.DOUBLE, "match (?1) against (?2)")
+        );
+    }
+}

--- a/culture-ticketing-core/src/main/java/com/culture/ticketing/show/domain/ShowFilter.java
+++ b/culture-ticketing-core/src/main/java/com/culture/ticketing/show/domain/ShowFilter.java
@@ -1,6 +1,9 @@
 package com.culture.ticketing.show.domain;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
 
 import static com.culture.ticketing.show.domain.QShow.show;
 
@@ -22,9 +25,17 @@ public class ShowFilter {
             builder.and(show.category.eq(this.category));
         }
         if (this.showName != null && !this.showName.isEmpty()) {
-            builder.and(show.showName.contains(showName));
+            builder.and(searchKeyword(showName));
         }
 
         return builder;
+    }
+
+    private BooleanExpression searchKeyword(String keyword) {
+
+        NumberTemplate<Double> booleanTemplate = Expressions.numberTemplate(Double.class,
+                "function('match',{0},{1})", show.showName, keyword);
+
+        return booleanTemplate.gt(0);
     }
 }

--- a/culture-ticketing-core/src/main/resources/application.yml
+++ b/culture-ticketing-core/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+        dialect: com.culture.ticketing.common.infra.MySQL8DialectCustom
 
   mvc:
     pathmatch:


### PR DESCRIPTION
기능:
- querydsl fulltext search 구문 dialect 설정 추가
- 공연 목록 조회 시 키워드 검색 구문 like절에서 fulltext search로 변경

이유:
- 공연명 키워드 포함 검색 (/api/v1/shows?offset=0&size=50&showName=콘서트) 시 공연명 관련 인덱스를 타지 못함
  - 공연명은 `show_name like '%키워드%'` 로 앞뒤로 %가 붙어있어서 인덱스를 탈 수 없음
- `like '%키워드%'` 대신 fulltext search 가능하도록 인덱스 추가

like: 

![](https://velog.velcdn.com/images/joona95/post/6644a9bd-9961-429a-bf2d-8988d603588d/image.png)

fulltext search:

![](https://velog.velcdn.com/images/joona95/post/fd09c18a-8fcb-4574-a754-6c470c3cd8cf/image.png)

![](https://velog.velcdn.com/images/joona95/post/da87e80a-beb1-4477-8953-0d9ad5e97c9b/image.png)


===

공연 목록 조회 시 필수로 order by 가 있어서 fulltext search를 썼을 때 filesort가 일어나게 되는데요. 

그래도 `like '%키워드%'`를 사용하면 전체 데이터를 훑게 되고 인덱스를 사용하더라도 정렬에서만 사용하는 거라 fulltext search가 더 나은 게 맞을지 궁금합니다.

일단 성능테스트 한 번 해보기 위해서 수정해봤습니다.